### PR TITLE
add explicit version for gym dependencies

### DIFF
--- a/gym/setup.py
+++ b/gym/setup.py
@@ -5,5 +5,5 @@ setup(name='f110_gym',
       author='Hongrui Zheng',
       author_email='billyzheng.bz@gmail.com',
       url='https://f1tenth.org',
-      install_requires=['gym', 'numpy', 'Pillow', 'scipy', 'numba', 'pyyaml', 'pyglet', 'pyopengl']
+      install_requires=['gym==0.20.0', 'numpy==1.20.3', 'Pillow==8.4.0', 'scipy==1.9.2', 'numba==0.54.0', 'pyyaml==5.4.1', 'pyglet==1.5.27', 'pyopengl==3.1.6']
       )


### PR DESCRIPTION
Hello all!  I was trying to follow along with the YouTube videos and I ran into an issue when trying to run the "Follow the Gap" example:

```
(/home/joe/work/github/f1tenth/ESweek2021_educationclassA3/.conda) joe@joe-pc:~/work/github/f1tenth/ESweek2021_educationclassA3/01_Follow_The_Gap(main)$ python3 FollowTheGap.py 
Traceback (most recent call last):
  File "FollowTheGap.py", line 82, in <module>
    runner.run()
  File "FollowTheGap.py", line 55, in run
    env.render()
  File "/home/joe/work/github/f1tenth/ESweek2021_educationclassA3/gym/f110_gym/envs/f110_env.py", line 391, in render
    F110Env.renderer.update_map(self.map_name, self.map_ext)
  File "/home/joe/work/github/f1tenth/ESweek2021_educationclassA3/gym/f110_gym/envs/rendering.py", line 153, in update_map
    self.batch.add(1, GL_POINTS, None, ('v3f/stream', [map_points[i, 0], map_points[i, 1], map_points[i, 2]]), ('c3B/stream', [183, 193, 222]))
AttributeError: 'Batch' object has no attribute 'add'
```

It looks like there was a breaking API change introduced with the [release of `pyglet` v2.0.0](https://pypi.org/project/pyglet/).  After pegging the versions of the `gym` dependencies, the demo runs as expected (i.e., the GUI pops up and the simulated car drives around the obstacles).

Thanks for sharing these examples and the videos on YouTube.  I'm looking forward to going them!